### PR TITLE
[FEAT]#44 Swagger 로그인 엔드포인트 추가 및 로그아웃 버그 fix

### DIFF
--- a/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
@@ -10,6 +10,26 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        // /login 경로에 대한 설명 추가
+        Schema<?> loginSchema = new ObjectSchema()
+                .addProperty("username", new StringSchema().example("string"))
+                .addProperty("password", new StringSchema().example("string"));
+
+        RequestBody loginRequestBody = new RequestBody()
+                .required(true)
+                .content(new Content().addMediaType("application/json",
+                        new MediaType().schema(loginSchema)));
+
+        Operation loginOperation = new Operation()
+                .summary("로그인 (Spring Security 필터 사용)")
+                .addTagsItem("auth-controller")
+                .requestBody(loginRequestBody)
+                .responses(new ApiResponses()
+                        .addApiResponse("201", new ApiResponse().description("로그인 성공 - JWT 반환"))
+                        .addApiResponse("401", new ApiResponse().description("인증 실패")));
+
+        PathItem loginPathItem = new PathItem().post(loginOperation);
+
         return new OpenAPI()
                 .info(new Info().title("API 문서").version("v1"))
                 .addSecurityItem(new SecurityRequirement().addList("AccessToken( Bearer없이 토큰만 넣어주세요:) )"))

--- a/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
@@ -1,6 +1,13 @@
 package com.ceos.spring_vote_21st.global.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ceos/spring_vote_21st/global/config/SwaggerConfig.java
@@ -11,6 +11,15 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .info(new Info().title("API 문서").version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList("AccessToken( Bearer없이 토큰만 넣어주세요:) )"))
+                .components(new Components()
+                        .addSecuritySchemes("AccessToken( Bearer없이 토큰만 넣어주세요:) )", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("Bearer")
+                                .bearerFormat("JWT")))
+
+                .paths(new Paths().addPathItem("/api/v1/auth/signin", loginPathItem))
                 // Swagger-UI Try it out → "/api/..." 상대 경로로 호출
                 .addServersItem(new Server().url("/"));
     }

--- a/src/main/java/com/ceos/spring_vote_21st/global/response/domain/ServiceCode.java
+++ b/src/main/java/com/ceos/spring_vote_21st/global/response/domain/ServiceCode.java
@@ -31,8 +31,8 @@ public enum ServiceCode {
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "미지원하는 토큰입니다"),
 
     // not defined
-    NOT_DEFINED_ERROR(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다")
-    ;
+    NOT_DEFINED_ERROR(HttpStatus.BAD_REQUEST, "정의 되지 않은 에러입니다"),
+    TOKEN_LOGOUT(HttpStatus.BAD_REQUEST, "로그아웃한 사용자입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ceos/spring_vote_21st/security/auth/web/controller/AuthController.java
+++ b/src/main/java/com/ceos/spring_vote_21st/security/auth/web/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.ceos.spring_vote_21st.security.auth.application.service.AuthService;
 import com.ceos.spring_vote_21st.security.auth.application.service.TokenReissueService;
 import com.ceos.spring_vote_21st.security.auth.web.dto.SignUpDTO;
 import io.netty.handler.ssl.PemPrivateKey;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ import org.springframework.web.util.WebUtils;
 
 import java.util.Map;
 
-
+@Tag(name = "auth-controller")
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")

--- a/src/main/java/com/ceos/spring_vote_21st/security/config/SecurityConfig.java
+++ b/src/main/java/com/ceos/spring_vote_21st/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.ceos.spring_vote_21st.member.domain.Role;
 import com.ceos.spring_vote_21st.security.auth.application.filter.CustomAuthenticationFilter;
 import com.ceos.spring_vote_21st.security.auth.application.filter.JwtAuthorizationFilter;
 import com.ceos.spring_vote_21st.security.auth.application.jwt.JwtTokenProvider;
+import com.ceos.spring_vote_21st.security.auth.application.jwt.blacklist.BlacklistTokenService;
 import com.ceos.spring_vote_21st.security.auth.application.jwt.refresh.RefreshTokenService;
 import com.ceos.spring_vote_21st.security.handler.JwtAuthenticationFailureHandler;
 import com.ceos.spring_vote_21st.security.handler.JwtAuthenticationSuccessHandler;
@@ -33,6 +34,7 @@ public class SecurityConfig {
     private final JwtAuthenticationSuccessHandler jwtSuccessHandler;
     private final JwtAuthenticationFailureHandler jwtFailureHandler;
     private final RefreshTokenService refreshTokenService;
+    private final BlacklistTokenService blacklistTokenService;
     private final CorsConfig corsConfig;
 
     @Bean
@@ -58,15 +60,16 @@ public class SecurityConfig {
                                         "/swagger-ui.html",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
-                                        // health
-                                        "/health",
-                                        "/health/new",
                                         // admin
                                         "/api/v1/admin/**",
                                         // member
                                         "/api/v1/members/**",
                                         // election
-                                        "/api/v1/elections/**"
+                                        "/api/v1/elections/**",
+                                        // health
+                                        "/health",
+                                        "/health/new",
+                                        "/error"
 
                                 ).permitAll()   // 인증 불필요
 //                                .requestMatchers("/api/v1/admin/**").hasRole(Role.ROLE_ADMIN.getKey())
@@ -74,7 +77,7 @@ public class SecurityConfig {
 //                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(
-                        new JwtAuthorizationFilter(jwtTokenProvider, userDetailsService, refreshTokenService),  // JWT 인가 필터 추가
+                        new JwtAuthorizationFilter(jwtTokenProvider, userDetailsService, refreshTokenService, blacklistTokenService),  // JWT 인가 필터 추가
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .addFilterAt(customAuthenticationFilter(authConfig.getAuthenticationManager()), UsernamePasswordAuthenticationFilter.class)  // 자체 인증 필터 추가


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #44 
close #45 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
액세스토큰을 필터에서 블랙리스트인지 검증하지 않는 문제를 발견하고 즉시 수정했습니다. 이제 로그아웃된 토큰으로는 인증이 불가합니다!
시큐리티필터에서 처리하기에 노출되지 않았던 로그인 엔드포인트를 swagger에 추가했습니다

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?