### PR TITLE
[FIX]#50 CORS 트러블 슈팅 및 선거 삭제

### DIFF
--- a/src/main/java/com/ceos/spring_vote_21st/vote/service/ElectionService.java
+++ b/src/main/java/com/ceos/spring_vote_21st/vote/service/ElectionService.java
@@ -194,7 +194,10 @@ public class ElectionService {
 
         findElection.removeCandidate(findCandidate);
     }
-
+    @Transactional
+    public void deleteAll() {
+        electionRepository.deleteAll();
+    }
     /**
      * other business
      * */
@@ -217,7 +220,5 @@ public class ElectionService {
         return ElectionResultDTO.from(ElectionResponseDTO.from(findElection), voteCounts);
     }
 
-    public void deleteAll() {
-        electionRepository.deleteAll();
-    }
+
 }


### PR DESCRIPTION
- 트랜잭션 적용 되지 않았기에 어노테이션 추가

<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #47 
close #50 



## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
1. CORS및 쿠키
우선 앞서 해결했던 swagger와 관련한 CORS문제를 다시 만나게되었고 해결했습니다. 기존에는 swagger의 요청경로가 잘못되었어서 요청 자체에 문제가 있었기에 상대경로로 설정함으로써 원래 도메인인 https://hanihome-vote.shop에 요청을 보낼 수 있었습니다.

- 문제상황: postman 상으로는 모든 메서드 요청 문제 없음. swagger에서 GET요청은 정상이지만 PUT,POST 등 preflight요청이 나가는 경우에는 모두 403오류 발생.

- 해결: 출처가 동일함에도 불구하고 브라우저에서는 fetch, xmlrequest등의 요청에 대해서 CORS헤더(ex, access-control-allow-origin) 을 요청한다. 따라서 동일 출처도 CorsConfig에서 허용할 출처 목록에 추가하였다.
2. 선거 삭제
트랜잭션 내에서 쿼리가 나가도록 변경

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?