### PR TITLE
[FIX]#58 ec2 도커 이미지 정리 자동화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,26 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             set -e
+            echo "Stopping containers..."
             sudo docker-compose down
-            sudo docker system prune -f
+            CONTAINER_ID=$(sudo docker ps -qf "ancestor=${{ secrets.DOCKERHUB_USERNAME }}/vote-server:latest")
+            
+            if [ -n "$CONTAINER_ID" ]; then
+              USED_ID=$(sudo docker inspect "$CONTAINER_ID" --format='{{.Image}}')
+            else
+              USED_ID="none"
+            fi
+            
+            echo "Removing unused vote-server images..."
+            for IMG_ID in $(sudo docker images ${{ secrets.DOCKERHUB_USERNAME }}/vote-server -q); do
+              if [ "$IMG_ID" != "$USED_ID" ]; then
+                echo "Removing unused image: $IMG_ID"
+                sudo docker rmi $IMG_ID || true
+              fi
+            done
+            
+            echo "Pulling latest image..."
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/vote-server:latest
+            
+            echo "Starting up containers..."
             sudo docker-compose up -d


### PR DESCRIPTION
- 현재 사용중인 이미지를 삭제한 후에 신규 이미지 pull하도록 변경

<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #58 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
문제상황: 
시스템 운영으로 인한 데이터가 쌓이면서 현재 서버가 운영중인 구이미지와 새로운 이미지인 신규이미지가 동시에 존재할 수 없을 정도로 용량이 부족해짐.
하지만 현재 코드상 태그가 붙어있지 않은 이미지만 삭제하는 로직이므로 해결이 안됨.
이를 해결하기 위하여 새로운 이미지를 pull받기 전에 기존 latest 이미지를 제거한 후 pull을 받도록 변경한다.

변경:
- 구이미지와 신규이미지가 볼륨에 동시에 존재하지 않도록 구이미지를 미리 삭제


## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?